### PR TITLE
add empty label if no label comes through in forms API

### DIFF
--- a/templates/form/form-element-label.html.twig
+++ b/templates/form/form-element-label.html.twig
@@ -23,3 +23,6 @@
 {% if title is not empty or required -%}
   <label{{ attributes.addClass(classes) }}>{{ title }}</label>
 {%- endif %}
+  {% if title_display not in ['after','before'] %}
+    <label{{ attributes.addClass(classes) }}></label>
+ {% endif %}


### PR DESCRIPTION
Materializecss requires a label for it to transform the checkbox correctly. If It comes through forms API and no label is present, you just won't see the checkbox at all. This adds a blank label if there is none to avoid checkboxes not showing up.

For examples, Features_ui module does not provide a label (for some reason?) to download an archive of the feature. without this update, you see no checkbox.