### PR TITLE
Display an empty form label if none is defined.

### DIFF
--- a/templates/form/form-element-label.html.twig
+++ b/templates/form/form-element-label.html.twig
@@ -20,6 +20,4 @@
     required ? 'form-required',
   ]
 %}
-{% if title is not empty or required -%}
-  <label{{ attributes.addClass(classes) }}>{{ title }}</label>
-{%- endif %}
+<label{{ attributes.addClass(classes) }}>{{ title }}</label>

--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -68,9 +68,7 @@
   ]
 %}
 <div{{ attributes.addClass(classes) }}>
-  {% if label_display == 'none' and label['#id'] %}
-    <label for="{{ label['#id'] }}"></label>
-  {% elseif label_display in ['before', 'invisible'] %}
+  {% if label_display in ['before', 'invisible', 'none'] %}
     {{ label }}
   {% endif %}
   {% if prefix is not empty %}

--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -68,7 +68,9 @@
   ]
 %}
 <div{{ attributes.addClass(classes) }}>
-  {% if label_display in ['before', 'invisible'] %}
+  {% if label_display == 'none' and label['#id'] %}
+    <label for="{{ label['#id'] }}"></label>
+  {% elseif label_display in ['before', 'invisible'] %}
     {{ label }}
   {% endif %}
   {% if prefix is not empty %}


### PR DESCRIPTION
This is an alternate fix for #12