### PR TITLE
Cleaned up description.html.twig and fixed non ANSI characters.

### DIFF
--- a/templates/form/field-multiple-value-form.html.twig
+++ b/templates/form/field-multiple-value-form.html.twig
@@ -22,9 +22,7 @@
 {% if multiple %}
   <div class="js-form-item form-item">
     {{ table }}
-    {% if description.content %}
-      {% include '@material_admin/misc/description.html.twig' %}
-    {% endif %}
+    {% include '@material_admin/misc/description.html.twig' %}
     {% if button %}
       <div class="clearfix">{{ button }}</div>
     {% endif %}

--- a/templates/form/fieldset.html.twig
+++ b/templates/form/fieldset.html.twig
@@ -53,8 +53,6 @@
     {% if suffix %}
       <span class="field-suffix">{{ suffix }}</span>
     {% endif %}
-    {% if description.content %}
-         {% include '@material_admin/misc/description.html.twig' %}
-    {% endif %}
+    {% include '@material_admin/misc/description.html.twig' %}
   </div>
 </fieldset>

--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -86,7 +86,7 @@
       <strong>{{ errors }}</strong>
     </div>
   {% endif %}
-  {% if description_display in ['after', 'invisible'] and description.content %}
-   {% include '@material_admin/misc/description.html.twig' %}
+  {% if description_display in ['after', 'invisible'] %}
+    {% include '@material_admin/misc/description.html.twig' %}
   {% endif %}
 </div>

--- a/templates/misc/description.html.twig
+++ b/templates/misc/description.html.twig
@@ -2,6 +2,12 @@
 /**
  * @file
  * Description styling
+ *
+ * Available variables:
+ * - description: Either a singleton (markup), or an array in the format:
+ *    - content: A description of the form element, may not be set.
+ *    - attributes: (optional) A list of HTML attributes to apply to the
+ *      description content wrapper. Will only be set when description is set.
 #}
 
 {%
@@ -10,10 +16,18 @@
     description_display == 'invisible' ? 'visually-hidden',
   ]
 %}
-    <div{{ description.attributes.addClass(description_classes) }}>
-    {% if description.content is not empty %}
-         <a class="tooltipped" data-position="bottom" data-delay="50" data-html="true" data-tooltip="{{ description.content|e('html')|convert_encoding('UTF-8', 'HTML-ENTITIES') }}">More info <i class="material-icons" aria-hidden="true">help</i></a>
-      {% else %}
-        <a class="tooltipped" data-position="bottom" data-delay="50" data-html="true" data-tooltip="{{ description|e('html')|convert_encoding('UTF-8', 'HTML-ENTITIES') }}">More info <i class="material-icons" aria-hidden="true">help</i></a>
-    {% endif %}
-    </div>
+
+{% if description is not iterable %}
+  {%
+    set description = {
+      content: description,
+      attributes: create_attribute({}),
+    }
+  %}
+{% endif %}
+
+{% if description.content is not empty %}
+  <div{{ description.attributes.addClass(description_classes) }}>
+    <a class="tooltipped" data-position="bottom" data-delay="50" data-html="true" data-tooltip="{{ render_var(description.content) | e('html_attr') }}">More info <i class="material-icons" aria-hidden="true">help</i></a>
+  </div>
+{% endif %}


### PR DESCRIPTION
This PR cleans up description.html.twig and the templates that call it, and fixes non ANSI characters not being rendered correctly. I also cleaned up the filtering a bit so that the only thing that runs through the description text is `e('html_attr')`, which simply escapes quotes in the string so that HTML descriptions still work without escaping out of the attribute.