### PR TITLE
Increasing the height of the .modal.bottom-sheet

### DIFF
--- a/css/material_admin.css
+++ b/css/material_admin.css
@@ -5474,7 +5474,7 @@ input[type=range]:focus::-ms-fill-upper {
   bottom: -100%;
   margin: 0;
   width: 100%;
-  max-height: 45%;
+  max-height: 95%;
   border-radius: 0;
   will-change: bottom, opacity; }
 


### PR DESCRIPTION
The bottom sheet for notifications is pretty short and requires scrolling to view longer messages. Since the modal isn't any larger than it needs to be, it should have a taller max height.